### PR TITLE
feat: add basic login screen

### DIFF
--- a/app/components/header/Header.tsx
+++ b/app/components/header/Header.tsx
@@ -4,9 +4,14 @@ import { chatStore } from '~/lib/stores/chat';
 import { classNames } from '~/utils/classNames';
 import { HeaderActionButtons } from './HeaderActionButtons.client';
 import { ChatDescription } from '~/lib/persistence/ChatDescription.client';
+import { authStore, logout } from '~/lib/stores/auth';
+import { Button } from '~/components/ui/Button';
+import { useNavigate } from '@remix-run/react';
 
 export function Header() {
   const chat = useStore(chatStore);
+  const auth = useStore(authStore);
+  const navigate = useNavigate();
 
   return (
     <header
@@ -23,7 +28,7 @@ export function Header() {
           <img src="/logo-dark-styled.png" alt="logo" className="w-[90px] inline-block hidden dark:block" />
         </a>
       </div>
-      {chat.started && ( // Display ChatDescription and HeaderActionButtons only when the chat has started.
+      {chat.started && (
         <>
           <span className="flex-1 px-4 truncate text-center text-bolt-elements-textPrimary">
             <ClientOnly>{() => <ChatDescription />}</ClientOnly>
@@ -37,6 +42,24 @@ export function Header() {
           </ClientOnly>
         </>
       )}
+      <div className="ml-auto">
+        {auth.isAuthenticated ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              logout();
+              navigate('/login');
+            }}
+          >
+            Logout
+          </Button>
+        ) : (
+          <Button variant="ghost" size="sm" onClick={() => navigate('/login')}>
+            Login
+          </Button>
+        )}
+      </div>
     </header>
   );
 }

--- a/app/lib/persistence/db.ts
+++ b/app/lib/persistence/db.ts
@@ -348,11 +348,7 @@ export async function deleteSnapshot(db: IDBDatabase, chatId: string): Promise<v
   });
 }
 
-export async function saveSession(
-  db: IDBDatabase,
-  token: string,
-  username: string,
-): Promise<void> {
+export async function saveSession(db: IDBDatabase, token: string, username: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const transaction = db.transaction('session', 'readwrite');
     const store = transaction.objectStore('session');
@@ -363,9 +359,7 @@ export async function saveSession(
   });
 }
 
-export async function getSession(
-  db: IDBDatabase,
-): Promise<{ token: string; username: string } | undefined> {
+export async function getSession(db: IDBDatabase): Promise<{ token: string; username: string } | undefined> {
   return new Promise((resolve, reject) => {
     const transaction = db.transaction('session', 'readonly');
     const store = transaction.objectStore('session');

--- a/app/lib/stores/auth.ts
+++ b/app/lib/stores/auth.ts
@@ -1,10 +1,5 @@
 import { atom } from 'nanostores';
-import {
-  openDatabase,
-  saveSession,
-  getSession,
-  deleteSession,
-} from '~/lib/persistence/db';
+import { openDatabase, saveSession, getSession, deleteSession } from '~/lib/persistence/db';
 
 export interface AuthState {
   isAuthenticated: boolean;
@@ -16,9 +11,13 @@ export const authStore = atom<AuthState>({ isAuthenticated: false });
 // Load session from IndexedDB on startup
 openDatabase()
   .then(async (db) => {
-    if (!db) return;
+    if (!db) {
+      return;
+    }
+
     try {
       const session = await getSession(db);
+
       if (session) {
         authStore.set({ isAuthenticated: true, username: session.username });
       }
@@ -34,6 +33,7 @@ export async function login(username: string, _password: string) {
   authStore.set(newState);
 
   const db = await openDatabase();
+
   if (db) {
     try {
       await saveSession(db, crypto.randomUUID(), username);
@@ -47,6 +47,7 @@ export async function logout() {
   authStore.set({ isAuthenticated: false });
 
   const db = await openDatabase();
+
   if (db) {
     try {
       await deleteSession(db);

--- a/app/lib/stores/auth.ts
+++ b/app/lib/stores/auth.ts
@@ -1,0 +1,57 @@
+import { atom } from 'nanostores';
+import {
+  openDatabase,
+  saveSession,
+  getSession,
+  deleteSession,
+} from '~/lib/persistence/db';
+
+export interface AuthState {
+  isAuthenticated: boolean;
+  username?: string;
+}
+
+export const authStore = atom<AuthState>({ isAuthenticated: false });
+
+// Load session from IndexedDB on startup
+openDatabase()
+  .then(async (db) => {
+    if (!db) return;
+    try {
+      const session = await getSession(db);
+      if (session) {
+        authStore.set({ isAuthenticated: true, username: session.username });
+      }
+    } catch (e) {
+      console.error('Failed to load session', e);
+    }
+  })
+  .catch((e) => console.error('Failed to open DB for auth', e));
+
+export async function login(username: string, _password: string) {
+  // A real app would verify credentials server-side
+  const newState = { isAuthenticated: true, username };
+  authStore.set(newState);
+
+  const db = await openDatabase();
+  if (db) {
+    try {
+      await saveSession(db, crypto.randomUUID(), username);
+    } catch (e) {
+      console.error('Failed to save session', e);
+    }
+  }
+}
+
+export async function logout() {
+  authStore.set({ isAuthenticated: false });
+
+  const db = await openDatabase();
+  if (db) {
+    try {
+      await deleteSession(db);
+    } catch (e) {
+      console.error('Failed to delete session', e);
+    }
+  }
+}

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,0 +1,45 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from '@remix-run/react';
+import { json } from '@remix-run/cloudflare';
+import { useStore } from '@nanostores/react';
+import { authStore, login } from '~/lib/stores/auth';
+import { Input } from '~/components/ui/Input';
+import { Button } from '~/components/ui/Button';
+import { Header } from '~/components/header/Header';
+import BackgroundRays from '~/components/ui/BackgroundRays';
+
+export const loader = () => json({});
+
+export default function Login() {
+  const auth = useStore(authStore);
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  useEffect(() => {
+    if (auth.isAuthenticated) {
+      navigate('/');
+    }
+  }, [auth.isAuthenticated, navigate]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    login(username, password);
+    navigate('/');
+  };
+
+  return (
+    <div className="flex flex-col h-full w-full bg-bolt-elements-background-depth-1">
+      <BackgroundRays />
+      <Header />
+      <form className="flex flex-col gap-4 m-auto w-80" onSubmit={handleSubmit}>
+        <h1 className="text-2xl text-center text-bolt-elements-textPrimary">Login</h1>
+        <Input placeholder="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
+        <Input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        <Button type="submit" className="mt-2">
+          Sign In
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/types/build-server.d.ts
+++ b/types/build-server.d.ts
@@ -1,0 +1,1 @@
+declare module '../build/server';


### PR DESCRIPTION
## Summary
- add `auth` store to persist login state
- include login/logout buttons in the header
- create new `login` route with a simple form
- store auth session data in IndexedDB instead of localStorage

## Testing
- `pnpm run lint` *(fails: Cannot find package '@blitz/eslint-plugin')*
- `pnpm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686247adc0488325b33de41139cb0e80